### PR TITLE
Add blog post about J5 v1.0

### DIFF
--- a/src/news/johnny-five-1-point-0.md
+++ b/src/news/johnny-five-1-point-0.md
@@ -9,10 +9,10 @@ category:
   - Platform
 ---
 
-Hi from [JSConf US](https://2018.jsconf.us/) in sunny San Diego, Calif., where a representative group of Johnny-Five contributors [met and planned](https://github.com/rwaldron/johnny-five/issues/1463) what's next for Johnny-Five. And—ta-da!—we are thrilled to announce the release of Johnny-Five v1.0!
+Hi from [JSConf US](https://2018.jsconf.us/) in sunny San Diego, Calif., where a representative group of Johnny-Five contributors [met and planned](https://github.com/rwaldron/johnny-five/issues/1463) what's next for Johnny-Five. And—ta-da!—we are thrilled to announce the release of Johnny-Five v1.0.0!
 
-Don't panic. This is the Johnny-Five you already know and love. There are no breaking changes from the last released, tagged version (???0.15.1). In fact, there are zero changes at all.
+Don't panic. This is the Johnny-Five you already know and love. There are no breaking changes from the most recent released, tagged version (v0.15.1). In fact, there are zero changes at all.
 
-But! Now we've got our [semver](https://semver.org/) wheels in motion. We're in a good position to start kicking out some of the features we've been excited about (but have been scared to ship because some are breaking).
+We're committing to the support of both [LTS (Long-Term Support) branches of Node.js](https://github.com/nodejs/Release), which, at time of versioning are: 8.x (active LTS) and 6.x (maintenance LTS). Already succesfully running J5 on an older version of Node.js? That's OK; it's not going to stop working overnight. We are, however, marching boldly forward: be forewarned that future releases may break on unsupported versions of Node.js.
 
-We're committing to the support of both [LTS (Long-Term Support) branches of Node.js](https://github.com/nodejs/Release), which, at time of versioning are: 8.x (active LTS) and 6.x (maintenance LTS). Already succesfully running J5 on an older version of Node.js? Not to worry: it won't stop working. We're just being more thoughtful and explicit about our Node.js version support going forward.
+Now we've got our [semver](https://semver.org/) wheels in motion. We're in a good position to start kicking out some of the features we've been excited about (but have been scared to ship because some are breaking). Stay tuned!

--- a/src/news/johnny-five-1-point-0.md
+++ b/src/news/johnny-five-1-point-0.md
@@ -1,0 +1,18 @@
+---
+author: Bryan Hughes and Lyza Danger Garder
+date: '2018-08-23 00:00:00'
+status: published
+title: 'Johnny-Five v1.0'
+slug: 'v1_0'
+category:
+  - Announcement
+  - Platform
+---
+
+Hi from [JSConf US](https://2018.jsconf.us/) in sunny San Diego, Calif., where a representative group of Johnny-Five contributors [met and planned](https://github.com/rwaldron/johnny-five/issues/1463) what's next for Johnny-Five. And—ta-da!—we are thrilled to announce the release of Johnny-Five v1.0!
+
+Don't panic. This is the Johnny-Five you already know and love. There are no breaking changes from the last released, tagged version (???0.15.1). In fact, there are zero changes at all.
+
+But! Now we've got our [semver](https://semver.org/) wheels in motion. We're in a good position to start kicking out some of the features we've been excited about (but have been scared to ship because some are breaking).
+
+We're committing to the support of both [LTS (Long-Term Support) branches of Node.js](https://github.com/nodejs/Release), which, at time of versioning are: 8.x (active LTS) and 6.x (maintenance LTS). Already succesfully running J5 on an older version of Node.js? Not to worry: it won't stop working. We're just being more thoughtful and explicit about our Node.js version support going forward.

--- a/src/news/johnny-five-1-point-0.md
+++ b/src/news/johnny-five-1-point-0.md
@@ -9,9 +9,9 @@ category:
   - Platform
 ---
 
-Hi from [JSConf US](https://2018.jsconf.us/) in sunny San Diego, Calif., where a representative group of Johnny-Five contributors [met and planned](https://github.com/rwaldron/johnny-five/issues/1463) what's next for Johnny-Five. And—ta-da!—we are thrilled to announce the release of Johnny-Five v1.0.0!
+Hi from [JSConf US](https://2018.jsconf.us/) in sunny San Diego, Calif., where a representative group of Johnny-Five contributors [met and planned](https://github.com/rwaldron/johnny-five/issues/1463) what's next for Johnny-Five. And—ta-da!—we are thrilled to announce the release of [Johnny-Five v1.0.0](https://www.npmjs.com/package/johnny-five/v/1.0.0)!
 
-Don't panic. This is the Johnny-Five you already know and love. There are no breaking changes from the most recent released, tagged version (v0.15.1). In fact, there are zero changes at all.
+Don't panic. This is the Johnny-Five you already know and love. There are no breaking changes from the most recent released, tagged version ([v0.15.1](https://github.com/rwaldron/johnny-five/releases/tag/v0.15.1)). In fact, there are [zero changes at all](https://github.com/rwaldron/johnny-five/releases/tag/v1.0.0).
 
 We're committing to the support of both [LTS (Long-Term Support) branches of Node.js](https://github.com/nodejs/Release), which, at time of versioning are: 8.x (active LTS) and 6.x (maintenance LTS). Already succesfully running J5 on an older version of Node.js? That's OK; it's not going to stop working overnight. We are, however, marching boldly forward: be forewarned that future releases may break on unsupported versions of Node.js.
 

--- a/src/news/johnny-five-1-point-0.md
+++ b/src/news/johnny-five-1-point-0.md
@@ -1,5 +1,5 @@
 ---
-author: Bryan Hughes and Lyza Danger Garder
+author: Lyza Danger Garder
 date: '2018-08-23 00:00:00'
 status: published
 title: 'Johnny-Five v1.0'


### PR DESCRIPTION
Hello! This PR adds a (draft) blog post about the release of Johnny-Five 1.0. Please do not merge as-is! We need to (at the least) determine whether we're going to tag another pre-release before 1.0, and @nebrius should get a change to do editorial revision.